### PR TITLE
remove height's style since it can be wrong

### DIFF
--- a/src/vue-pdf-embed.vue
+++ b/src/vue-pdf-embed.vue
@@ -317,7 +317,6 @@ export default {
               canvas.style.height = `${Math.floor(actualWidth)}px`
             } else {
               canvas.style.width = `${Math.floor(actualWidth)}px`
-              canvas.style.height = `${Math.floor(actualHeight)}px`
             }
 
             await this.renderPage(page, canvas, actualWidth)


### PR DESCRIPTION
Le pluggin vue-embed rajoute une couche de style essentiellement pour centrer le pdf dans le viewer, on garde le traitement sur la width qui centre bien mais on enlève le traitement sur le height qui ne sert pas à grand chose et peut en plus provoquer des bugs